### PR TITLE
perf: avoid array.shift, use a linked list

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
       "@commitlint/config-conventional"
     ],
     "rules": {
-      "body-max-length": [
+      "body-max-line-length": [
         0
       ]
     }

--- a/src/create.js
+++ b/src/create.js
@@ -6,16 +6,16 @@ class Node {
   }
 }
 
-class DoublyLinkedList {
+class LinkedList {
   enqueue (data) {
-    const node = new Node(data)
     if (!this.head) {
-      this.head = node
-      this.tail = node
+      this.head = new Node(data)
     } else {
-      node.prev = this.tail
-      this.tail.next = node
-      this.tail = node
+      let current = this.head
+      while (current.next) {
+        current = current.next
+      }
+      current.next = new Node(data)
     }
   }
 
@@ -23,14 +23,12 @@ class DoublyLinkedList {
     if (!this.head) return
     const data = this.head.data
     this.head = this.head.next
-    if (this.head) this.head.prev = undefined
-    else this.tail = undefined
     return data
   }
 }
 
 module.exports = (slots = 1) => {
-  const queue = new DoublyLinkedList()
+  const queue = new LinkedList()
 
   const release = () => {
     ++slots

--- a/src/create.js
+++ b/src/create.js
@@ -43,9 +43,7 @@ module.exports = (slots = 1) => {
 
   const lock = () =>
     new Promise(resolve =>
-      lock.isLocked()
-        ? queue.enqueue(acquire.bind(null, resolve))
-        : acquire(resolve)
+      lock.isLocked() ? queue.enqueue(() => acquire(resolve)) : acquire(resolve)
     )
 
   lock.isLocked = () => slots === 0

--- a/src/create.js
+++ b/src/create.js
@@ -1,11 +1,41 @@
 'use strict'
 
+class Node {
+  constructor (data) {
+    this.data = data
+  }
+}
+
+class DoublyLinkedList {
+  enqueue (data) {
+    const node = new Node(data)
+    if (!this.head) {
+      this.head = node
+      this.tail = node
+    } else {
+      node.prev = this.tail
+      this.tail.next = node
+      this.tail = node
+    }
+  }
+
+  dequeue () {
+    if (!this.head) return
+    const data = this.head.data
+    this.head = this.head.next
+    if (this.head) this.head.prev = undefined
+    else this.tail = undefined
+    return data
+  }
+}
+
 module.exports = (slots = 1) => {
-  const queue = []
+  const queue = new DoublyLinkedList()
 
   const release = () => {
     ++slots
-    if (queue.length > 0) queue.shift()()
+    const fn = queue.dequeue()
+    if (fn !== undefined) fn()
   }
 
   const acquire = resolve => {
@@ -16,7 +46,7 @@ module.exports = (slots = 1) => {
   const lock = () =>
     new Promise(resolve =>
       lock.isLocked()
-        ? queue.push(acquire.bind(null, resolve))
+        ? queue.enqueue(acquire.bind(null, resolve))
         : acquire(resolve)
     )
 


### PR DESCRIPTION
Instead of stacking promises into an array, it uses a linked list <picture data-single-emoji=":kekwait:" title=":kekwait:"><img class="emoji" width="20" height="auto" src="https://emoji.slack-edge.com/T0CAQ00TU/kekwait/52522159c491a989.png" alt=":kekwait:" align="absmiddle"></picture> 

The main advantage is that `queue.shift` hurts performance for large arrays cases because O(n), while a linked list keeps access time O(1) <picture data-single-emoji=":doge-eyebrows:" title=":doge-eyebrows:"><img class="emoji" width="20" height="auto" src="https://emoji.slack-edge.com/T0CAQ00TU/doge-eyebrows/85945f054ce6b7a4.gif" alt=":doge-eyebrows:" align="absmiddle"></picture> 

Related: https://github.com/nodejs/node/issues/42449#issue-1178964076